### PR TITLE
Add mruby-string-ext dependency

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -3,4 +3,5 @@ MRuby::Gem::Specification.new('mruby-open3') do |spec|
   spec.authors = 'Takashi Kokubun'
   spec.add_dependency 'mruby-io'
   spec.add_dependency 'mruby-process'
+  spec.add_dependency 'mruby-string-ext', core: 'mruby-string-ext'
 end


### PR DESCRIPTION
String#<< is defined in mruby-string-ext.