### PR TITLE
mrb_open3_spawn: Handle execvp error

### DIFF
--- a/src/mrb_open3.c
+++ b/src/mrb_open3.c
@@ -6,6 +6,9 @@
 ** See Copyright Notice in LICENSE
 */
 
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
 #include "mruby.h"
 #include "mruby/hash.h"
@@ -80,6 +83,10 @@ mrb_open3_spawn(mrb_state *mrb, mrb_value self)
       chdir(options.chdir);
     }
     execvp(cmd[0], cmd);
+
+    // execvp does not return on success.
+    fprintf(stderr, "execvp(%s): %s", cmd[0], strerror(errno));
+    _exit(EXIT_FAILURE);
   }
   return mrb_fixnum_value(pid);
 }


### PR DESCRIPTION
Terminates the `fork`ed child process when `execvp` fails with printing a simple error message. Without doing so, the child process will continue and do whatever the parent process does.

Ideally, for compatibility with MRI's `Process.spawn`, we want to hand the error back to the parent process and raise a `SystemCallError`, but this patch does not implement it.

---

This patch fixes a problem in mitamae that `gem_package` resource with non-existent `gem_binary` makes recipe application stopped forever.  I would appreciate your updating mitamae after merging this patch.